### PR TITLE
Warning fixes and CI -Werror

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
     - name: autoreconf
       run: autoreconf -i
     - name: configure
-      run: ./configure CXXFLAGS=-Werror
+      run: ./configure CXXFLAGS="-Wall -Werror"
     - name: make
       run: make
     - name: make check

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,7 @@ jobs:
     - name: autoreconf
       run: autoreconf -i
     - name: configure
-      run: ./configure
+      run: ./configure CXXFLAGS=-Werror
     - name: make
       run: make
     - name: make check

--- a/Thing.CoAP/Client.cpp
+++ b/Thing.CoAP/Client.cpp
@@ -106,7 +106,8 @@ namespace Thing
 		ObserveToken Client::Observe(std::string endpoint, ResponseCallback callback)
 		{
 			const uint16_t messageID = currentMessageId++;
-			uint8_t tokens[2] = { (messageID >> 8) & 0xFF, messageID & 0xFF };
+			uint8_t tokens[2] = { static_cast<uint8_t>((messageID >> 8) & 0xFF),
+			                      static_cast<uint8_t>(messageID & (uint8_t)0xFF) };
 
 			Thing::CoAP::Packet request;
 			request.SetVersion(1);
@@ -138,7 +139,7 @@ namespace Thing
 			const uint16_t messageID = currentMessageId++;
 			const uint16_t tokenID = token.GetToken();
 			std::string endpoint = token.GetEndpoint();
-			uint8_t tokens[2] = { (tokenID >> 8) & 0xFF, tokenID & 0xFF };
+			uint8_t tokens[2] = { static_cast<uint8_t>((tokenID >> 8) & 0xFF), static_cast<uint8_t>(tokenID & 0xFF) };
 
 			Thing::CoAP::Packet request;
 			request.SetVersion(1);
@@ -207,7 +208,7 @@ namespace Thing
 				return;
 
 			const uint16_t messageID = currentMessageId++;
-			uint8_t tokens[2] = { (messageID >> 8) & 0xFF, messageID & 0xFF };
+			uint8_t tokens[2] = { static_cast<uint8_t>((messageID >> 8) & 0xFF), static_cast<uint8_t>(messageID & 0xFF) };
 
 			Thing::CoAP::Packet request;
 			request.SetVersion(1);

--- a/Thing.CoAP/Observer.h
+++ b/Thing.CoAP/Observer.h
@@ -21,8 +21,12 @@ namespace Thing {
 
 			Observer& operator=(const Observer& other)
 			{
-				Observer o(other);
-				return o;
+				ip = other.ip;
+				port = other.port;
+				count = other.count;
+				tokens = other.tokens;
+				messageID = other.messageID;
+				return *this;
 			}
 
 			bool operator==(const Observer& other) const
@@ -30,11 +34,11 @@ namespace Thing {
 				return ip == other.ip && port == other.port;
 			}
 		private:
-			const IPAddress ip;
-			const int port;
-			const std::vector<uint8_t> tokens;
-			uint16_t count;
+			IPAddress ip;
+			int port;
 			uint16_t messageID;
+			std::vector<uint8_t> tokens;
+			uint16_t count;
 		};
 	}
 }

--- a/Thing.CoAP/Server.cpp
+++ b/Thing.CoAP/Server.cpp
@@ -56,7 +56,6 @@ namespace Thing {
 		{
 		}
 
-#pragma region Endpoint Management
 		IFunctionalResource& Server::CreateResource(std::string name, Thing::CoAP::ContentFormat content, bool IsObservable)
 		{
 			FunctionalResource* endpoint = new FunctionalResource(name, content, IsObservable);
@@ -87,7 +86,6 @@ namespace Thing {
 		{
 			RemoveResource(&endpoint);
 		}
-#pragma endregion
 
 		void Server::SetPort(int port)
 		{
@@ -162,6 +160,8 @@ namespace Thing {
 					{
 					case Thing::CoAP::MessageType::Confirmable: response.SetType(Thing::CoAP::MessageType::Acknowledge); break;
 					case Thing::CoAP::MessageType::NonConfirmable: response.SetType(Thing::CoAP::MessageType::NonConfirmable); break;
+					case Thing::CoAP::MessageType::Acknowledge: break;
+					case Thing::CoAP::MessageType::Reset: break;
 					}
 
 					std::map<std::string, AvailableResource>::iterator it = this->resources.find(url);
@@ -206,6 +206,9 @@ namespace Thing {
 						case Thing::CoAP::Method::Put: e = resource->Put(request); break;
 						case Thing::CoAP::Method::Post: e = resource->Post(request); break;
 						case Thing::CoAP::Method::Delete: e = resource->Delete(request); break;
+						case Thing::CoAP::Method::Content: break;
+						case Thing::CoAP::Method::NotFound: break;
+						case Thing::CoAP::Method::Empty: break;
 						}
 
 						std::string statusPayload = e.GetPayload();
@@ -268,7 +271,6 @@ namespace Thing {
 			SetPacketProvider(&provider);
 		}
 
-#pragma region Private Methods
 		void Server::removeObserver(std::string& url, Thing::CoAP::Observer & obs)
 		{
 			if (url.size() > 0)
@@ -348,6 +350,5 @@ namespace Thing {
 			option.SetNumber(Thing::CoAP::OptionValue::ContentFormat);
 			option.SetOption(optionBuffer, 2);
 		}
-#pragma endregion
 	}
 }

--- a/Thing.CoAP/WebLink.cpp
+++ b/Thing.CoAP/WebLink.cpp
@@ -63,7 +63,11 @@ namespace Thing
 					this->hasMaximumSizeEstimate = true;
 				}
 				else if (type == "ct")
-					sscanf(value.c_str(), "%d", &this->contentFormat);
+				{
+				    int contentFormat = 0;
+					sscanf(value.c_str(), "%d", &contentFormat);
+					this->contentFormat = static_cast<ContentFormat>(contentFormat);
+				}
 				else if (type == "title")
 				{
 					this->title = value.substr(1, value.size() - 2); //Title is a string and we must remove the quotes.

--- a/tests/ClientTest.cpp
+++ b/tests/ClientTest.cpp
@@ -62,7 +62,7 @@ namespace Thing {
 				EXPECT_EQ(Method::Get, request.GetCode());
 				EXPECT_EQ(Thing::CoAP::MessageType::NonConfirmable, request.GetType());
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint.c_str(), endpoint.size())));
-				ASSERT_EQ(0, request.GetPayload().size());
+				ASSERT_EQ(0ul, request.GetPayload().size());
 
 				//It's enough to return the same sent packet as fot his test, we only want to make sure the callback is called and for that, the sent token just need to match the incoming token
 				EXPECT_CALL(packetProviderMock, ReadPacket(_, _, _)).Times(1).WillOnce(DoAll(SetArgPointee<0>(networkPacket), Return(true)));
@@ -97,7 +97,7 @@ namespace Thing {
 				EXPECT_EQ(Method::Get, request.GetCode());
 				EXPECT_EQ(Thing::CoAP::MessageType::NonConfirmable, request.GetType());
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint.c_str(), endpoint.size())));
-				ASSERT_EQ(0, request.GetPayload().size());
+				ASSERT_EQ(0ul, request.GetPayload().size());
 
 				//It's enough to return the same sent packet as fot his test, we only want to make sure the callback is called and for that, the sent token just need to match the incoming token
 				EXPECT_CALL(packetProviderMock, ReadPacket(_, _, _)).Times(1).WillOnce(DoAll(SetArgPointee<0>(networkPacket), Return(true)));
@@ -428,14 +428,14 @@ namespace Thing {
 				request.DesserializePacket(networkPacket);
 
 				uint16_t tokenID = token.GetToken();
-				uint8_t tokens[2] = { (tokenID >> 8) & 0xFF, tokenID & 0xFF };
+				uint8_t tokens[2] = { static_cast<uint8_t>((tokenID >> 8) & 0xFF), static_cast<uint8_t>(tokenID & 0xFF) };
 				EXPECT_EQ(Method::Get, request.GetCode());
-				EXPECT_EQ(2, request.GetTokens().size());
+				EXPECT_EQ(2ul, request.GetTokens().size());
 				EXPECT_TRUE(0 == std::memcmp(&tokens[0], &request.GetTokens()[0], 2));
 				EXPECT_EQ(Thing::CoAP::MessageType::NonConfirmable, request.GetType());
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint.c_str(), endpoint.size())));
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)NULL, 0)));
-				ASSERT_EQ(0, request.GetPayload().size());
+				ASSERT_EQ(0ul, request.GetPayload().size());
 
 				//It's enough to return the same sent packet as fot his test, we only want to make sure the callback is called and for that, the sent token just need to match the incoming token
 				EXPECT_CALL(packetProviderMock, ReadPacket(_, _, _)).Times(1).WillOnce(DoAll(SetArgPointee<0>(networkPacket), Return(true)));
@@ -475,7 +475,7 @@ namespace Thing {
 				EXPECT_EQ(Thing::CoAP::MessageType::NonConfirmable, request.GetType());
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint.c_str(), endpoint.size())));
 				EXPECT_THAT(request.GetOptions(), Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)&observeOption, 1)));
-				ASSERT_EQ(0, request.GetPayload().size());
+				ASSERT_EQ(0ul, request.GetPayload().size());
 			}
 		}
 	}

--- a/tests/PacketTest.cpp
+++ b/tests/PacketTest.cpp
@@ -54,9 +54,9 @@ namespace Thing {
 				EXPECT_EQ(0, memcmp(tokens, &packet.GetTokens()[0], sizeof(tokens)));
 
 				std::vector<Thing::CoAP::Option> optionsP = packet.GetOptions();
-				for (int i = 0; i < optionsP.size(); ++i)
+				for (size_t i = 0; i < optionsP.size(); ++i)
 				{
-					EXPECT_EQ(i, static_cast<int>(optionsP[i].GetNumber()));
+					EXPECT_EQ(i, static_cast<size_t>(optionsP[i].GetNumber()));
 					EXPECT_EQ(sizeof(optionsBuffer), optionsP[i].GetLenght());
 					EXPECT_EQ(0, memcmp(optionsBuffer, optionsP[i].GetBuffer(), sizeof(optionsBuffer)));
 				}
@@ -116,9 +116,9 @@ namespace Thing {
 				EXPECT_TRUE(0 == std::memcmp(tokens, &p.GetTokens()[0], sizeof(tokens)));
 
 				std::vector<Thing::CoAP::Option>& pOptions = p.GetOptions();
-				EXPECT_EQ(6, pOptions.size());
+				EXPECT_EQ(6ul, pOptions.size());
 				int runningDelta = 0;
-				for (int i = 0; i < pOptions.size(); ++i)
+				for (size_t i = 0; i < pOptions.size(); ++i)
 				{
 					Thing::CoAP::Option option = pOptions[i];
 
@@ -218,9 +218,9 @@ namespace Thing {
 				EXPECT_TRUE(0 == std::memcmp(tokens, &p.GetTokens()[0], sizeof(tokens)));
 
 				std::vector<Thing::CoAP::Option>& pOptions = p.GetOptions();
-				EXPECT_EQ(6, pOptions.size());
+				EXPECT_EQ(6ul, pOptions.size());
 				int runningDelta = 0;
-				for (int i = 0; i < pOptions.size(); ++i)
+				for (size_t i = 0; i < pOptions.size(); ++i)
 				{
 					Thing::CoAP::Option option = pOptions[i];
 
@@ -279,9 +279,6 @@ namespace Thing {
 				const uint8_t option4[] = { 0x04, 0xD4, 0x04 }; //Option Number = 30 + (269 + 160) = 459
 				const uint8_t option5[] = { 0x03, 0xC3, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03 }; //Option Number 459 + (269 + 2976) = 3704
 				const uint8_t option6[270] = {};
-				const int optionsSize[] = { sizeof(option1), sizeof(option2), sizeof(option3), sizeof(option4), sizeof(option5), sizeof(option6) };
-				const uint8_t* options[] = { option1, option2, option3, option4, option5, option6 };
-				const uint8_t payloadMarker = 0xFF;
 				const uint8_t payload[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A };
 
 				std::memset((uint8_t*)option6, 0x01, sizeof(option6));
@@ -333,14 +330,14 @@ namespace Thing {
 
 				EXPECT_EQ(version, (buffer[0] >> 6) & 0b00000011);
 				EXPECT_EQ(type, (buffer[0] >> 4) & 0b00000011);
-				EXPECT_EQ(sizeof(tokens), buffer[0] & 0b00001111);
+				EXPECT_EQ(sizeof(tokens), static_cast<size_t>(buffer[0] & 0b00001111));
 				EXPECT_EQ(code, buffer[1]);
 				EXPECT_EQ(transactionID, ((buffer[2] << 8) & 0xFF00) | (buffer[3] & 0xFF));
 				EXPECT_TRUE(0 == std::memcmp((uint8_t*)tokens, &buffer[4], sizeof(tokens)));
 
 				int runningDelta = 0;
 				uint8_t* p = &buffer[4 + sizeof(tokens)];
-				for (int i = 0; i < pOptions.size(); ++i)
+				for (size_t i = 0; i < pOptions.size(); ++i)
 				{
 					int currentDelta = 0 | ((p[0] >> 4) & 0x0F);
 					uint16_t currentLength = p[0] & 0x0F;
@@ -382,7 +379,7 @@ namespace Thing {
 					p = aux + option.GetLenght();
 				}
 
-				EXPECT_EQ(0xFF, p[0]);
+				EXPECT_EQ(static_cast<uint8_t>(0xFF), p[0]);
 				EXPECT_TRUE(0 == std::memcmp(&p[1], payload, sizeof(payload)));
 			}
 
@@ -413,7 +410,7 @@ namespace Thing {
 
 				packet.SetPayload(NULL, 0);
 
-				EXPECT_EQ(0, packet.GetPayload().size());
+				EXPECT_EQ(0ul, packet.GetPayload().size());
 			}
 		
 			TEST_F(PacketTest, SetPayload)

--- a/tests/ServerTest.cpp
+++ b/tests/ServerTest.cpp
@@ -30,7 +30,7 @@ namespace Thing {
 			TEST_F(ServerTest, PortTest)
 			{
 				const int ports[] = { 1, 2, 3 };
-				for (int i = 0; i < sizeof(ports) / sizeof(int); ++i)
+				for (size_t i = 0; i < sizeof(ports) / sizeof(int); ++i)
 				{
 					Server.SetPort(ports[i]);
 					EXPECT_EQ(ports[i], Server.GetPort());
@@ -48,7 +48,6 @@ namespace Thing {
 				Server.SetPacketProvider(udpProviderMock);
 			}
 
-#pragma region Simple Endpoint Tests
 			void ServerTest::BaseEndpointTest(Thing::CoAP::Method method, Thing::CoAP::IResource& endpoint)
 			{
 				const std::string endpointPath = endpoint.GetName();
@@ -97,7 +96,7 @@ namespace Thing {
 
 				std::vector<Thing::CoAP::Option>& responseOptions = response.GetOptions();
 				EXPECT_THAT(responseOptions, ::testing::Contains(ContentFormat(contentFormat)));
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			void ServerTest::SimpleEndpointTest(Thing::CoAP::Method method)
@@ -180,9 +179,7 @@ namespace Thing {
 			{
 				FunctionalEndpointTest(Thing::CoAP::Method::Delete);
 			}
-#pragma endregion
 
-#pragma region Endpoint Not Found Tests
 			void ServerTest::EndpointNotFoundTest(Thing::CoAP::Method method)
 			{
 				const std::string endpointPath = "EndpointNotExist";
@@ -191,7 +188,6 @@ namespace Thing {
 				const Thing::CoAP::IPAddress requestIPAddress = 0x01010101;
 				const int requestPort = 1234;
 				const uint8_t version = 1;
-				const Thing::CoAP::ContentFormat contentFormat = Thing::CoAP::ContentFormat::ApplicationJSon;
 				const Thing::CoAP::MessageType messageType = Thing::CoAP::MessageType::NonConfirmable;
 
 				Thing::CoAP::Packet request;
@@ -230,8 +226,8 @@ namespace Thing {
 				EXPECT_TRUE(0 == std::memcmp(&request.GetTokens()[0], &response.GetTokens()[0], response.GetTokens().size()));
 
 				std::vector<Thing::CoAP::Option>& responseOptions = response.GetOptions();
-				EXPECT_EQ(0, responseOptions.size());
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, responseOptions.size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			TEST_F(ServerTest, NoEndpointFoundGetTesting)
@@ -252,7 +248,6 @@ namespace Thing {
 			{
 				EndpointNotFoundTest(Thing::CoAP::Method::Delete);
 			}
-#pragma endregion
 
 			void ServerTest::MultipleEndpointTest(ResourceMock* endpoint, int size, int callIndex, Thing::CoAP::Method method)
 			{
@@ -308,7 +303,7 @@ namespace Thing {
 
 				std::vector<Thing::CoAP::Option>& responseOptions = response.GetOptions();
 				EXPECT_THAT(responseOptions, ::testing::Contains(ContentFormat(contentFormat)));
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			TEST_F(ServerTest, MultipleEndpointTest)
@@ -331,7 +326,6 @@ namespace Thing {
 					MultipleEndpointTest(endpoint, totalEndpoints, i, Thing::CoAP::Method::Get);
 			}
 
-#pragma region Resource Discovery Test
 			void ServerTest::ResourceDiscoveryTest(std::vector<uint8_t>* responseBuffer)
 			{
 				const std::string endpointPath = ".well-known/core";
@@ -390,7 +384,7 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			TEST_F(ServerTest, ResourceDiscoverySimpleTest_InterfaceDescription)
@@ -412,12 +406,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -442,12 +436,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -473,12 +467,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -503,12 +497,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -534,12 +528,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -564,12 +558,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -595,12 +589,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -625,12 +619,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -656,12 +650,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -687,12 +681,12 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
 				std::list<WebLink> links = WebLink::ParseString(payload);
-				EXPECT_EQ(1, links.size());
+				EXPECT_EQ(1ul, links.size());
 
 				EXPECT_EQ(endpointName, links.begin()->GetURI());
 				EXPECT_EQ(contentFormat, links.begin()->GetContentFormat());
@@ -701,12 +695,12 @@ namespace Thing {
 
 			TEST_F(ServerTest, ResourceDiscoveryMultipleTest)
 			{
-				const int totalEndpoints = 10;
+				const size_t totalEndpoints = 10;
 				const std::string endpointBaseName = "Endpoint";
 				const Thing::CoAP::ContentFormat contentFormat = Thing::CoAP::ContentFormat::ApplicationJSon;
 				ResourceMock endpoint[totalEndpoints];
 
-				for (int i = 0; i < totalEndpoints; ++i)
+				for (size_t i = 0; i < totalEndpoints; ++i)
 				{
 					EXPECT_CALL(endpoint[i], GetName()).WillRepeatedly(Return(endpointBaseName + std::to_string(i)));
 					EXPECT_CALL(endpoint[i], GetContentFormat()).WillRepeatedly(Return(contentFormat));
@@ -721,7 +715,7 @@ namespace Thing {
 				Thing::CoAP::Packet response;
 				response.DesserializePacket(responseBuffer);
 
-				EXPECT_NE(0, response.GetPayload().size());
+				EXPECT_NE(0ul, response.GetPayload().size());
 
 				std::string payload = std::string(reinterpret_cast<char*>(&response.GetPayload()[0]), response.GetPayload().size());
 
@@ -736,15 +730,11 @@ namespace Thing {
 				}
 			}
 
-#pragma endregion
-
-#pragma region Observers Test
 			void ServerTest::ObserveTest(bool observe, Thing::CoAP::IPAddress requestIPAddress, int requestPort, std::vector<uint8_t> tokens, std::string endpoint, uint8_t** responseBuffer, int* responseLength)
 			{
 				const std::string endpointPath = endpoint;
 				const uint16_t messageID = 0x1234;
 				const uint8_t version = 1;
-				const Thing::CoAP::ContentFormat contentFormat = Thing::CoAP::ContentFormat::ApplicationJSon;
 				const Thing::CoAP::MessageType messageType = Thing::CoAP::MessageType::NonConfirmable;
 
 				Thing::CoAP::Packet request;
@@ -786,7 +776,6 @@ namespace Thing {
 				const std::string endpointPath = "";
 				const uint16_t messageID = 0x1234;
 				const uint8_t version = 1;
-				const Thing::CoAP::ContentFormat contentFormat = Thing::CoAP::ContentFormat::ApplicationJSon;
 				const Thing::CoAP::MessageType messageType = Thing::CoAP::MessageType::Reset;
 
 				Thing::CoAP::Packet request;
@@ -858,9 +847,9 @@ namespace Thing {
 					EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 					EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 					std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-					EXPECT_EQ(3, responseOptions.size());
+					EXPECT_EQ(3ul, responseOptions.size());
 
-					uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+					uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 					EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 					EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 					EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -895,7 +884,7 @@ namespace Thing {
 					uint8_t* responseBuffer = NULL;
 					int responseLength = 0;
 					std::vector<uint8_t> packetTokens;
-					for (int j = 0; j < sizeof(tokens); ++j)
+					for (size_t j = 0; j < sizeof(tokens); ++j)
 						packetTokens.push_back(tokens[j]);
 					packetTokens[0] = i;
 					ObserveTest(true, requestIPAddress | (uint8_t)i, requestPort | (uint8_t)i, packetTokens, endpointPath, &responseBuffer, &responseLength);
@@ -926,9 +915,9 @@ namespace Thing {
 						EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 						EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 						std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-						EXPECT_EQ(3, responseOptions.size());
+						EXPECT_EQ(3ul, responseOptions.size());
 
-						uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+						uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 						EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -955,11 +944,11 @@ namespace Thing {
 				const uint8_t tokens[] = { 0x01, 0x02, 0x03, 0x04 };
 				const std::string observePacketPayload = "Observe Test";
 				const int totalNotifications = 5;
-				const int totalEndpoints = 10;
+				const size_t totalEndpoints = 10;
 
 				ResourceMock endpoint[totalEndpoints];
 
-				for (int i = 0; i < totalEndpoints; ++i)
+				for (size_t i = 0; i < totalEndpoints; ++i)
 				{
 					EXPECT_CALL(endpoint[i], IsObservable()).WillRepeatedly(Return(true));
 					EXPECT_CALL(endpoint[i], GetName()).WillRepeatedly(Return(endpointPath + std::to_string(i)));
@@ -969,7 +958,7 @@ namespace Thing {
 				}
 				Server.Start();
 
-				for (int i = 0; i < totalEndpoints; ++i)
+				for (size_t i = 0; i < totalEndpoints; ++i)
 				{
 					if (i % 2 == 0)
 						continue;
@@ -983,7 +972,7 @@ namespace Thing {
 					delete[] responseBuffer;
 				}
 
-				for (int j = 0; j < totalEndpoints; ++j)
+				for (size_t j = 0; j < totalEndpoints; ++j)
 					for (int i = 0; i < totalNotifications; ++i)
 					{
 						std::vector<uint8_t> observeBuffer;
@@ -1003,9 +992,9 @@ namespace Thing {
 						EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 						EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 						std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-						EXPECT_EQ(3, responseOptions.size());
+						EXPECT_EQ(3ul, responseOptions.size());
 
-						uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+						uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint[j].GetName().c_str(), endpoint[j].GetName().size())));
 						EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1056,7 +1045,7 @@ namespace Thing {
 				EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 				EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 				std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-				EXPECT_EQ(3, responseOptions.size());
+				EXPECT_EQ(3ul, responseOptions.size());
 
 				EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 				EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1098,7 +1087,7 @@ namespace Thing {
 					uint8_t* responseBuffer = NULL;
 					int responseLength = 0;
 					std::vector<uint8_t> packetTokens;
-					for (int j = 0; j < sizeof(tokens); ++j)
+					for (size_t j = 0; j < sizeof(tokens); ++j)
 						packetTokens.push_back(tokens[j]);
 					packetTokens[0] = i;
 					ObserveTest(true, requestIPAddress | (uint8_t)i, requestPort | (uint8_t)i, packetTokens, endpointPath, &responseBuffer, &responseLength);
@@ -1126,9 +1115,9 @@ namespace Thing {
 						EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 						EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 						std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-						EXPECT_EQ(3, responseOptions.size());
+						EXPECT_EQ(3ul, responseOptions.size());
 
-						uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+						uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 						EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1215,9 +1204,9 @@ namespace Thing {
 						EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 						EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 						std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-						EXPECT_EQ(3, responseOptions.size());
+						EXPECT_EQ(3ul, responseOptions.size());
 
-						uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+						uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 						EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint[j].GetName().c_str(), endpoint[j].GetName().size())));
 						EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1293,9 +1282,9 @@ namespace Thing {
 					EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 					EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 					std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-					EXPECT_EQ(3, responseOptions.size());
+					EXPECT_EQ(3ul, responseOptions.size());
 
-					uint8_t observeOption[2] = { (i + 2) >> 8, (i + 2) };
+					uint8_t observeOption[2] = { static_cast<uint8_t>((i + 2) >> 8), static_cast<uint8_t>(i + 2) };
 					EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::Observe, (uint8_t*)observeOption, 2)));
 					EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 					EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1371,7 +1360,7 @@ namespace Thing {
 
 				std::vector<Thing::CoAP::Option>& responseOptions = response.GetOptions();
 				EXPECT_THAT(responseOptions, ::testing::Contains(ContentFormat(contentFormat)));
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			TEST_F(ServerTest, ObserveRemoveRequestButEndpointIsNotObservable)
@@ -1442,7 +1431,7 @@ namespace Thing {
 
 				std::vector<Thing::CoAP::Option>& responseOptions = response.GetOptions();
 				EXPECT_THAT(responseOptions, ::testing::Contains(ContentFormat(contentFormat)));
-				EXPECT_EQ(0, response.GetPayload().size());
+				EXPECT_EQ(0ul, response.GetPayload().size());
 			}
 
 			TEST_F(ServerTest, ObserveRemoveAllSingleEndpointTest)
@@ -1486,7 +1475,7 @@ namespace Thing {
 				EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 				EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 				std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-				EXPECT_EQ(3, responseOptions.size());
+				EXPECT_EQ(3ul, responseOptions.size());
 
 				EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpointPath.c_str(), endpointPath.size())));
 				EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1550,7 +1539,7 @@ namespace Thing {
 					EXPECT_EQ(Thing::CoAP::MessageType::Confirmable, observePacket.GetType());
 					EXPECT_EQ(static_cast<int>(Thing::CoAP::ResponseCode::Content), static_cast<int>(observePacket.GetCode()));
 					std::vector<Thing::CoAP::Option>& responseOptions = observePacket.GetOptions();
-					EXPECT_EQ(3, responseOptions.size());
+					EXPECT_EQ(3ul, responseOptions.size());
 
 					EXPECT_THAT(responseOptions, Contains(Option(Thing::CoAP::OptionValue::URIPath, (uint8_t*)endpoint[i].GetName().c_str(), endpoint[i].GetName().size())));
 					EXPECT_THAT(responseOptions, Contains(ContentFormat(Thing::CoAP::ContentFormat::ApplicationJSon)));
@@ -1565,7 +1554,6 @@ namespace Thing {
 				for(int i = 0; i < totalResources; ++i)
 					Server.NotifyObservers(endpoint[i], Thing::CoAP::Status::Content(observePacketPayload));
 			}
- #pragma endregion
 		}
 	}
 }

--- a/tests/StatusTest.cpp
+++ b/tests/StatusTest.cpp
@@ -31,7 +31,7 @@ namespace Thing {
 			{
 				Thing::CoAP::Status status = Thing::CoAP::Status::Content();
 
-				EXPECT_EQ(0, status.GetPayload().size());
+				EXPECT_EQ(0ul, status.GetPayload().size());
 				EXPECT_EQ(Thing::CoAP::ResponseCode::Content, status.GetCode());
 			}
 

--- a/tests/WebLinkTest.cpp
+++ b/tests/WebLinkTest.cpp
@@ -62,7 +62,7 @@ namespace Thing {
 			{
 				WebLink link(rawData);
 				ASSERT_TRUE(link.HasMaximumSizeEstimate());
-				ASSERT_EQ(10, link.GetMaximumSizeEstimate());
+				ASSERT_EQ(10ul, link.GetMaximumSizeEstimate());
 			}
 
 			TEST_F(WebLinkTest, MaximumSizeEstimateNotExistTest)
@@ -110,13 +110,13 @@ namespace Thing {
 			{
 				std::list<WebLink> links = WebLink::ParseString(rawData);
 
-				ASSERT_EQ(1, links.size());
+				ASSERT_EQ(1ul, links.size());
 
 				WebLink link = *links.begin();
 				ASSERT_EQ("test", link.GetURI());
 				ASSERT_EQ("observer", link.GetResourceType());
 				ASSERT_EQ("thing.coap", link.GetInterfaceDescription());
-				ASSERT_EQ(10, link.GetMaximumSizeEstimate());
+				ASSERT_EQ(10ul, link.GetMaximumSizeEstimate());
 				ASSERT_EQ(Thing::CoAP::ContentFormat::ApplicationJSon, link.GetContentFormat());
 				ASSERT_EQ(true, link.IsObservable());
 				ASSERT_EQ("Some Title", link.GetTitle());


### PR DESCRIPTION
While playing with this project and integrating into a project via platformio, the build failed due to compilation errors with newer gcc/clang compilers.  These changes force CI to build with -Wall -Werror and fix problems raised by those changes (almost all trivial).